### PR TITLE
refactor(kiste): replace static sql.unsafe with tagged template literals

### DIFF
--- a/packages/kiste/src/Indexer.ts
+++ b/packages/kiste/src/Indexer.ts
@@ -107,9 +107,11 @@ export const createSnapshot = (
 
     // Count artifacts
     const sql = yield* SqlClient.SqlClient;
-    const rows = yield* sql
-      .unsafe<{ count: number }>(`SELECT COUNT(*) as count FROM artifacts WHERE alive = 1`)
-      .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))));
+    const rows = yield* sql<{
+      count: number;
+    }>`SELECT COUNT(*) as count FROM artifacts WHERE alive = 1`.pipe(
+      Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))),
+    );
 
     return {
       sha: lastSha,
@@ -190,20 +192,21 @@ const maybeAutoSnapshot = (
     // Count commits since last snapshot
     let commitsSinceSnapshot: number;
     if (!lastSnapshotSha) {
-      const rows = yield* sql
-        .unsafe<{ count: number }>(`SELECT COUNT(*) as count FROM commits`)
-        .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))));
+      const rows = yield* sql<{
+        count: number;
+      }>`SELECT COUNT(*) as count FROM commits`.pipe(
+        Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))),
+      );
       commitsSinceSnapshot = rows[0].count;
     } else {
       // Count commits after the snapshot sha by timestamp
-      const rows = yield* sql
-        .unsafe<{ count: number }>(
-          `SELECT COUNT(*) as count FROM commits WHERE timestamp > (
-            SELECT timestamp FROM commits WHERE sha = ?
-          )`,
-          [lastSnapshotSha],
-        )
-        .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))));
+      const rows = yield* sql<{
+        count: number;
+      }>`SELECT COUNT(*) as count FROM commits WHERE timestamp > (
+            SELECT timestamp FROM commits WHERE sha = ${lastSnapshotSha}
+          )`.pipe(
+        Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))),
+      );
       commitsSinceSnapshot = rows[0].count;
     }
 
@@ -226,29 +229,14 @@ const processCommits = (
 
     // Wrap all commits in a single transaction for performance.
     // Without this, each INSERT/UPDATE is an implicit transaction (extremely slow for large repos).
-    const body = Effect.gen(function* () {
-      for (const commit of commits) {
-        const counts = yield* indexCommit(commit);
-        artifacts_indexed += counts.indexed;
-        artifacts_deleted += counts.deleted;
-      }
-    });
-
-    yield* sql
-      .unsafe("BEGIN")
-      .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))));
-    yield* body.pipe(
-      Effect.tap(() =>
-        sql
-          .unsafe("COMMIT")
-          .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e })))),
-      ),
-      Effect.catchAll((e) =>
-        sql.unsafe("ROLLBACK").pipe(
-          Effect.catchAll(() => Effect.void),
-          Effect.andThen(Effect.fail(e)),
-        ),
-      ),
+    yield* sql.withTransaction(
+      Effect.gen(function* () {
+        for (const commit of commits) {
+          const counts = yield* indexCommit(commit);
+          artifacts_indexed += counts.indexed;
+          artifacts_deleted += counts.deleted;
+        }
+      }),
     );
 
     return {
@@ -289,19 +277,9 @@ const indexCommit = (
     const tagOps = parseTagLine(commit.body);
 
     // Insert commit
-    yield* sql
-      .unsafe(
-        `INSERT OR IGNORE INTO commits (sha, message, author, timestamp, conv_type, conv_scope) VALUES (?, ?, ?, ?, ?, ?)`,
-        [
-          commit.sha,
-          commit.subject,
-          commit.author,
-          commit.timestamp,
-          conv?.type ?? null,
-          conv?.scope ?? null,
-        ],
-      )
-      .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))));
+    yield* sql`INSERT OR IGNORE INTO commits (sha, message, author, timestamp, conv_type, conv_scope) VALUES (${commit.sha}, ${commit.subject}, ${commit.author}, ${commit.timestamp}, ${conv?.type ?? null}, ${conv?.scope ?? null})`.pipe(
+      Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))),
+    );
 
     // Track affected artifact IDs for tag materialization
     const affectedArtifactIds = new Set<number>();
@@ -312,12 +290,12 @@ const indexCommit = (
     for (const filePath of commit.files) {
       if (isExcluded(filePath, excludeGlobs)) continue;
       // Upsert artifact
-      yield* sql
-        .unsafe(`INSERT OR IGNORE INTO artifacts (path, alive) VALUES (?, 1)`, [filePath])
-        .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))));
-      yield* sql
-        .unsafe(`UPDATE artifacts SET alive = 1 WHERE path = ?`, [filePath])
-        .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))));
+      yield* sql`INSERT OR IGNORE INTO artifacts (path, alive) VALUES (${filePath}, 1)`.pipe(
+        Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))),
+      );
+      yield* sql`UPDATE artifacts SET alive = 1 WHERE path = ${filePath}`.pipe(
+        Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))),
+      );
 
       const artifactRows = yield* sql<{
         id: number;
@@ -329,12 +307,9 @@ const indexCommit = (
       affectedArtifactIds.add(artifactId);
 
       // Insert artifact_commits link
-      yield* sql
-        .unsafe(`INSERT OR IGNORE INTO artifact_commits (artifact_id, commit_sha) VALUES (?, ?)`, [
-          artifactId,
-          commit.sha,
-        ])
-        .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))));
+      yield* sql`INSERT OR IGNORE INTO artifact_commits (artifact_id, commit_sha) VALUES (${artifactId}, ${commit.sha})`.pipe(
+        Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))),
+      );
 
       // Insert tag operations if present
       if (tagOps) {
@@ -347,12 +322,12 @@ const indexCommit = (
     for (const filePath of commit.deletedFiles) {
       if (isExcluded(filePath, excludeGlobs)) continue;
       // Ensure artifact exists
-      yield* sql
-        .unsafe(`INSERT OR IGNORE INTO artifacts (path, alive) VALUES (?, 0)`, [filePath])
-        .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))));
-      yield* sql
-        .unsafe(`UPDATE artifacts SET alive = 0 WHERE path = ?`, [filePath])
-        .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))));
+      yield* sql`INSERT OR IGNORE INTO artifacts (path, alive) VALUES (${filePath}, 0)`.pipe(
+        Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))),
+      );
+      yield* sql`UPDATE artifacts SET alive = 0 WHERE path = ${filePath}`.pipe(
+        Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))),
+      );
 
       const artifactRows = yield* sql<{
         id: number;
@@ -363,12 +338,9 @@ const indexCommit = (
       const artifactId = artifactRows[0].id;
       affectedArtifactIds.add(artifactId);
 
-      yield* sql
-        .unsafe(`INSERT OR IGNORE INTO artifact_commits (artifact_id, commit_sha) VALUES (?, ?)`, [
-          artifactId,
-          commit.sha,
-        ])
-        .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))));
+      yield* sql`INSERT OR IGNORE INTO artifact_commits (artifact_id, commit_sha) VALUES (${artifactId}, ${commit.sha})`.pipe(
+        Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))),
+      );
       deleted++;
     }
 
@@ -393,12 +365,9 @@ const insertTagOps = (
   Effect.forEach(
     ops,
     (op) =>
-      sql
-        .unsafe(
-          `INSERT INTO tag_operations (artifact_id, commit_sha, tag, op) VALUES (?, ?, ?, ?)`,
-          [artifactId, commitSha, op.tag, op.op],
-        )
-        .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e })))),
+      sql`INSERT INTO tag_operations (artifact_id, commit_sha, tag, op) VALUES (${artifactId}, ${commitSha}, ${op.tag}, ${op.op})`.pipe(
+        Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))),
+      ),
     { discard: true },
   );
 
@@ -439,16 +408,16 @@ const materializeTags = (
     );
 
     // 4. Rewrite artifact_tags
-    yield* sql
-      .unsafe(`DELETE FROM artifact_tags WHERE artifact_id = ?`, [artifactId])
-      .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))));
+    yield* sql`DELETE FROM artifact_tags WHERE artifact_id = ${artifactId}`.pipe(
+      Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))),
+    );
 
     yield* Effect.forEach(
       [...finalTags],
       (tag) =>
-        sql
-          .unsafe(`INSERT INTO artifact_tags (artifact_id, tag) VALUES (?, ?)`, [artifactId, tag])
-          .pipe(Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e })))),
+        sql`INSERT INTO artifact_tags (artifact_id, tag) VALUES (${artifactId}, ${tag})`.pipe(
+          Effect.catchAll((e) => Effect.fail(new DbError({ message: e.message, cause: e }))),
+        ),
       { discard: true },
     );
   });

--- a/packages/kiste/src/Tools.ts
+++ b/packages/kiste/src/Tools.ts
@@ -174,40 +174,36 @@ export function makeTools(run: RunEffect, repoDir: string): ToolDef[] {
             const git = yield* Git;
             yield* initSchema;
 
-            const artifactRows = yield* sql.unsafe<{ id: number; path: string; alive: number }>(
-              `SELECT id, path, alive FROM artifacts WHERE path = ?`,
-              [path],
-            );
+            const artifactRows = yield* sql<{
+              id: number;
+              path: string;
+              alive: number;
+            }>`SELECT id, path, alive FROM artifacts WHERE path = ${path}`;
             if (artifactRows.length === 0) {
               return { error: `Artifact not found: ${path}` };
             }
             const artifact = artifactRows[0];
 
-            const tagRows = yield* sql.unsafe<{ tag: string }>(
-              `SELECT tag FROM artifact_tags WHERE artifact_id = ?`,
-              [artifact.id],
-            );
+            const tagRows = yield* sql<{
+              tag: string;
+            }>`SELECT tag FROM artifact_tags WHERE artifact_id = ${artifact.id}`;
             const tags = tagRows.map((r) => r.tag);
 
-            const commitRows = yield* sql.unsafe<{
+            const commitRows = yield* sql<{
               sha: string;
               message: string;
               author: string;
               timestamp: number;
-            }>(
-              `SELECT c.sha, c.message, c.author, c.timestamp
+            }>`SELECT c.sha, c.message, c.author, c.timestamp
                FROM commits c
                JOIN artifact_commits ac ON ac.commit_sha = c.sha
-               WHERE ac.artifact_id = ?
+               WHERE ac.artifact_id = ${artifact.id}
                ORDER BY c.timestamp DESC
-               LIMIT 5`,
-              [artifact.id],
-            );
+               LIMIT 5`;
 
-            const totalCommitRows = yield* sql.unsafe<{ count: number }>(
-              `SELECT COUNT(*) as count FROM artifact_commits WHERE artifact_id = ?`,
-              [artifact.id],
-            );
+            const totalCommitRows = yield* sql<{
+              count: number;
+            }>`SELECT COUNT(*) as count FROM artifact_commits WHERE artifact_id = ${artifact.id}`;
             const totalCommits = totalCommitRows[0].count;
 
             const gitRef = ref ?? "HEAD";
@@ -271,15 +267,12 @@ export function makeTools(run: RunEffect, repoDir: string): ToolDef[] {
               return { results: rows, count: rows.length };
             }
 
-            const rows = yield* sql.unsafe(
-              `SELECT c.sha, c.message, c.author, c.timestamp
+            const rows = yield* sql`SELECT c.sha, c.message, c.author, c.timestamp
                FROM commits_fts fts
                JOIN commits c ON c.rowid = fts.rowid
-               WHERE commits_fts MATCH ?
+               WHERE commits_fts MATCH ${safeQuery}
                ORDER BY c.timestamp DESC
-               LIMIT ?`,
-              [safeQuery, lim],
-            );
+               LIMIT ${lim}`;
             return { results: rows, count: rows.length };
           }),
         );
@@ -300,15 +293,12 @@ export function makeTools(run: RunEffect, repoDir: string): ToolDef[] {
             const sql = yield* SqlClient.SqlClient;
             yield* initSchema;
 
-            const rows = yield* sql.unsafe(
-              `SELECT c.sha, c.message, c.author, c.timestamp
+            const rows = yield* sql`SELECT c.sha, c.message, c.author, c.timestamp
                FROM commits c
                JOIN artifact_commits ac ON ac.commit_sha = c.sha
                JOIN artifacts a ON a.id = ac.artifact_id
-               WHERE a.path = ?
-               ORDER BY c.timestamp ASC`,
-              [path],
-            );
+               WHERE a.path = ${path}
+               ORDER BY c.timestamp ASC`;
             return { commits: rows };
           }),
         );
@@ -333,25 +323,26 @@ export function makeTools(run: RunEffect, repoDir: string): ToolDef[] {
             const lim = limit ?? 20;
 
             // Check artifact exists
-            const artifactRows = yield* sql.unsafe<{ id: number }>(
-              `SELECT id FROM artifacts WHERE path = ?`,
-              [path],
-            );
+            const artifactRows = yield* sql<{
+              id: number;
+            }>`SELECT id FROM artifacts WHERE path = ${path}`;
             if (artifactRows.length === 0) {
               return { error: `Artifact not found: ${path}` };
             }
 
             // Count total commits for this artifact
-            const totalRows = yield* sql.unsafe<{ count: number }>(
-              `SELECT COUNT(*) as count FROM artifact_commits WHERE artifact_id = ?`,
-              [artifactRows[0].id],
-            );
+            const totalRows = yield* sql<{
+              count: number;
+            }>`SELECT COUNT(*) as count FROM artifact_commits WHERE artifact_id = ${artifactRows[0].id}`;
             const total_commits = totalRows[0].count;
 
             // Find co-changing files via self-join on artifact_commits
-            const rows = yield* sql.unsafe<{ path: string; shared_count: number; jaccard: number }>(
-              `WITH target AS (
-                SELECT id FROM artifacts WHERE path = ?
+            const rows = yield* sql<{
+              path: string;
+              shared_count: number;
+              jaccard: number;
+            }>`WITH target AS (
+                SELECT id FROM artifacts WHERE path = ${path}
               ),
               target_commits AS (
                 SELECT commit_sha FROM artifact_commits WHERE artifact_id = (SELECT id FROM target)
@@ -373,9 +364,7 @@ export function makeTools(run: RunEffect, repoDir: string): ToolDef[] {
               JOIN artifacts a ON a.id = c.artifact_id
               WHERE a.alive = 1
               ORDER BY c.shared_count DESC
-              LIMIT ?`,
-              [path, lim],
-            );
+              LIMIT ${lim}`;
 
             return {
               path,
@@ -409,10 +398,9 @@ export function makeTools(run: RunEffect, repoDir: string): ToolDef[] {
 
             const operation = op ?? "add";
 
-            const artifactRows = yield* sql.unsafe<{ id: number }>(
-              `SELECT id FROM artifacts WHERE path = ?`,
-              [path],
-            );
+            const artifactRows = yield* sql<{
+              id: number;
+            }>`SELECT id FROM artifacts WHERE path = ${path}`;
             if (artifactRows.length === 0) {
               return { error: `Artifact not found: ${path}` };
             }
@@ -420,24 +408,17 @@ export function makeTools(run: RunEffect, repoDir: string): ToolDef[] {
 
             if (operation === "add") {
               for (const tag of tags) {
-                yield* sql.unsafe(
-                  `INSERT OR IGNORE INTO artifact_tags (artifact_id, tag) VALUES (?, ?)`,
-                  [artifactId, tag],
-                );
+                yield* sql`INSERT OR IGNORE INTO artifact_tags (artifact_id, tag) VALUES (${artifactId}, ${tag})`;
               }
             } else {
               for (const tag of tags) {
-                yield* sql.unsafe(`DELETE FROM artifact_tags WHERE artifact_id = ? AND tag = ?`, [
-                  artifactId,
-                  tag,
-                ]);
+                yield* sql`DELETE FROM artifact_tags WHERE artifact_id = ${artifactId} AND tag = ${tag}`;
               }
             }
 
-            const currentTags = yield* sql.unsafe<{ tag: string }>(
-              `SELECT tag FROM artifact_tags WHERE artifact_id = ? ORDER BY tag`,
-              [artifactId],
-            );
+            const currentTags = yield* sql<{
+              tag: string;
+            }>`SELECT tag FROM artifact_tags WHERE artifact_id = ${artifactId} ORDER BY tag`;
 
             return { path, tags: currentTags.map((r) => r.tag) };
           }),
@@ -456,14 +437,12 @@ export function makeTools(run: RunEffect, repoDir: string): ToolDef[] {
             const sql = yield* SqlClient.SqlClient;
             yield* initSchema;
 
-            const rows = yield* sql.unsafe(
-              `SELECT at2.tag, COUNT(*) as count
+            const rows = yield* sql`SELECT at2.tag, COUNT(*) as count
                FROM artifact_tags at2
                JOIN artifacts a ON a.id = at2.artifact_id
                WHERE a.alive = 1
                GROUP BY at2.tag
-               ORDER BY count DESC, at2.tag ASC`,
-            );
+               ORDER BY count DESC, at2.tag ASC`;
             return { tags: rows };
           }),
         );


### PR DESCRIPTION
## Summary
- Convert 26 static sql.unsafe() calls to tagged template literals
- Replace manual BEGIN/COMMIT/ROLLBACK with sql.withTransaction()
- Keep sql.unsafe only for dynamic queries (variable WHERE, IN lists)

Closes #20

## Test plan
- [x] All 51 kiste tests pass
- [x] turbo check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated database query construction methods
  * Enhanced transaction handling in data processing operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->